### PR TITLE
docs: fix typo in .gitignore comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ pnpm-debug.log*
 # macOS-specific files
 .DS_Store
 
-# jetbrains setting folder
+# JetBrains settings folder
 .idea/


### PR DESCRIPTION
## Summary
- fix JetBrains comment in .gitignore

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684126e18ea0832cbd286aa6f397e2b4